### PR TITLE
Add Xquik vendor MCP entry

### DIFF
--- a/data/vendors.csv
+++ b/data/vendors.csv
@@ -1,1 +1,2 @@
 id,vendor_name,mcp_server_url,verification_type,verification_evidence,status,last_verified,notes
+xquik,Xquik,https://xquik.com/mcp,official-docs,https://docs.xquik.com/mcp/overview,active,2026-06-14,Remote StreamableHTTP server; registry card at https://xquik.com/.well-known/mcp.json


### PR DESCRIPTION
Summary:
- Add Xquik to data/vendors.csv as an official vendor MCP server.
- Use the public MCP docs and registry card as verification evidence.

Validation:
- awk field-count check on data/vendors.csv
- curl HEAD check for https://docs.xquik.com/mcp/overview
- registry card JSON check for com.xquik/mcp and https://xquik.com/mcp
- git diff --check