### PR TITLE
Add 7 marketplace entries (from #4) + CSV field-count validator

### DIFF
--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -1,0 +1,23 @@
+name: Validate CSV
+
+on:
+  pull_request:
+    paths:
+      - "data/*.csv"
+      - "scripts/validate_csv.py"
+      - ".github/workflows/validate-csv.yml"
+  push:
+    branches: [main]
+    paths:
+      - "data/*.csv"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Field-count check on data/*.csv
+        run: python3 scripts/validate_csv.py

--- a/data/marketplaces.csv
+++ b/data/marketplaces.csv
@@ -33,3 +33,10 @@ medium-nimrita-tutorial,Medium MCP Tutorial,tutorial,https://medium.com/@nimrita
 newstack-tutorial,The New Stack MCP Tutorial,tutorial,https://thenewstack.io/how-to-set-up-a-model-context-protocol-server/,The New Stack,active,,tier-3,2025-11-19,Setup guide
 simplescraper-tutorial,Simplescraper MCP Guide,tutorial,https://simplescraper.io/blog/how-to-mcp,Simplescraper,active,,tier-3,2025-11-19,How to MCP complete guide
 apidog-tutorial,Apidog MCP Tutorial,tutorial,https://apidog.com/blog/build-an-mcp-server/,Apidog,active,,tier-3,2025-11-19,Beginner guide
+mcp-directory,MCP.Directory,catalog-site,https://mcp.directory/,Unknown,active,3000+,tier-1,2026-05-04,Specialized servers for browser automation and API management
+cursor-ide-mcp,Cursor IDE MCP Marketplace,built-in-app,https://cursor.com/marketplace,Cursor,active,,tier-1,2026-05-04,IDE-native MCP discovery for agentic coding
+github-copilot-extensions,GitHub Copilot MCP Extensions,built-in-app,https://github.com/marketplace,GitHub,active,,tier-1,2026-05-04,Copilot Extensions predominantly MCP-compliant
+jetbrains-eclipse-mcp,JetBrains/Eclipse MCP Marketplace,built-in-app,https://plugins.jetbrains.com/,JetBrains / Eclipse Foundation,active,,tier-1,2026-05-04,IDE-specific registry with allowlist controls - public preview Oct 2025
+mcpmed,MCPmed,catalog-site,https://mcpmed.org,Community / Academic,active,,tier-2,2026-05-04,"Specialized bioinformatics and genomics MCP servers (GEOmcp, STRING MCP)"
+databricks-mcp-marketplace,Databricks MCP Marketplace,marketplace,https://marketplace.databricks.com/,Databricks,announced,Unknown,tier-2,2026-05-04,Enterprise focus with Moody's LSEG S&P Global FactSet Nasdaq - announced Nov 2025
+mcp-universe,MCP-Universe,research-dataset,https://mcp-universe.github.io/mcp-servers-hubs.html,Academic,active,11,tier-3,2026-05-04,Curated benchmark set (~11 servers) used for evaluation research

--- a/scripts/validate_csv.py
+++ b/scripts/validate_csv.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate that every row in each data/*.csv has the header's field count.
+
+Catches the two classic hand-edited-CSV bugs:
+  - a trailing comma (an extra empty field), and
+  - an unquoted comma inside a value (which splits one field into two).
+
+Uses the stdlib csv parser, so commas inside properly *quoted* fields are fine.
+Exits non-zero if any row's field count differs from its header's.
+
+Usage:
+    scripts/validate_csv.py                # all data/*.csv
+    scripts/validate_csv.py data/foo.csv   # specific file(s)
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+
+def validate(path: str) -> list[str]:
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        return [f"{path}: empty file (no header)"]
+    expected = len(rows[0])
+    errors = []
+    for lineno, row in enumerate(rows[1:], start=2):
+        if len(row) != expected:
+            errors.append(
+                f"{path}:{lineno}: expected {expected} fields, found {len(row)} -> {row}"
+            )
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    targets = argv[1:] or sorted(str(p) for p in (repo_root / "data").glob("*.csv"))
+    if not targets:
+        print("no CSV files found under data/", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for t in targets:
+        errs = validate(t)
+        all_errors += errs
+        print(f"  {'FAIL' if errs else 'ok  '}  {t}  ({len(errs)} issue(s))")
+
+    if all_errors:
+        print("\nField-count mismatches:", file=sys.stderr)
+        for e in all_errors:
+            print("  " + e, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Learn-and-rebuild of #4 (@codeninja23). That PR's 7 entries are good data but were CSV-malformed (trailing commas → 11 fields; an unquoted comma in the MCPmed notes split the field). This re-lands the same 7 entries cleanly **and** adds a guard so it can't recur.

**Entries added:** MCP.Directory, Cursor IDE MCP Marketplace, GitHub Copilot MCP Extensions, JetBrains/Eclipse MCP Marketplace, MCPmed, Databricks MCP Marketplace, MCP-Universe.

**Validator:** `scripts/validate_csv.py` checks every row's field count against the header (stdlib csv parser, so properly-quoted commas are fine), wired as a `Validate CSV` GitHub Actions check on PRs touching `data/*.csv`. Verified it passes the cleaned file and flags both malformed-row classes from #4.

Credit to @codeninja23 in #4 for the research; closing #4 in favor of this.